### PR TITLE
Allow anonymous access to key form pages

### DIFF
--- a/app/forms/personal-injury/page.tsx
+++ b/app/forms/personal-injury/page.tsx
@@ -57,7 +57,7 @@ interface UploadedFile {
 }
 
 export default function PersonalInjuryForm() {
-  const { user, loading, userProfile } = useAuth();
+  const { loading, userProfile } = useAuth();
   const router = useRouter();
   const { uploadMultipleDocuments, uploading } = useDocumentUpload();
 
@@ -311,11 +311,6 @@ export default function PersonalInjuryForm() {
         </div>
       </>
     );
-  }
-
-  if (!user) {
-    router.push("/forms");
-    return null;
   }
 
   const handleFileUpload = async (files: FileList, category: string) => {

--- a/app/forms/wrongful-death/page.tsx
+++ b/app/forms/wrongful-death/page.tsx
@@ -49,7 +49,7 @@ interface UploadedFile {
 }
 
 export default function WrongfulDeathForm() {
-  const { user, loading, userProfile } = useAuth();
+  const { loading, userProfile } = useAuth();
   const router = useRouter();
   const { uploadMultipleDocuments, uploading } = useDocumentUpload();
 
@@ -255,11 +255,6 @@ export default function WrongfulDeathForm() {
         </div>
       </>
     );
-  }
-
-  if (!user) {
-    router.push("/forms");
-    return null;
   }
 
   const handleFileUpload = async (files: FileList, category: string) => {

--- a/app/forms/wrongful-termination/page.tsx
+++ b/app/forms/wrongful-termination/page.tsx
@@ -39,7 +39,7 @@ interface UploadedFile {
 }
 
 export default function WrongfulTerminationForm() {
-  const { user, loading, userProfile } = useAuth();
+  const { loading, userProfile } = useAuth();
   const router = useRouter();
   const { uploadMultipleDocuments, uploading } = useDocumentUpload();
 
@@ -260,11 +260,6 @@ export default function WrongfulTerminationForm() {
         </div>
       </>
     );
-  }
-
-  if (!user) {
-    router.push("/forms");
-    return null;
   }
 
   const handleFileUpload = async (files: FileList, category: string) => {

--- a/middleware.ts
+++ b/middleware.ts
@@ -38,9 +38,6 @@ export async function middleware(request: NextRequest) {
 
   // Protected routes - add paths that require authentication
   const protectedPaths = [
-    '/forms/personal-injury',
-    '/forms/wrongful-death',
-    '/forms/wrongful-termination',
     '/profile',
     '/admin',
     '/firms',


### PR DESCRIPTION
## Summary
- Permit unauthenticated visitors to reach personal injury, wrongful death, and wrongful termination forms
- Remove client-side auth checks from those form pages

## Testing
- `npm test` *(fails: Syntax Error in tests)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689504a960b88333be7244f125f40bbe